### PR TITLE
Update decorators.ts

### DIFF
--- a/decorators.ts
+++ b/decorators.ts
@@ -46,7 +46,7 @@ export function Inject<T = any>(
       { prop: new Map(), param: new Map() };
 
     let cident: ServiceIdent<T> | undefined = ident;
-    if (typeof paramIndex !== "undefined") {
+    if (typeof paramIndex === "number") {
       if (typeof cident === "undefined") {
         const designParams = getClassParamTypes(tgt);
         const designType = designParams?.[paramIndex];


### PR DESCRIPTION
In bundled code the third parameter passed to the decorator is the PropertyDescriptor and therefore not undefined.  With this change it looks for `paramIndex` to be a number as passed in parameter decorators.

Fixes #6 